### PR TITLE
Raising the amount of simultaneous connections a frontend can take to 12k

### DIFF
--- a/spec/haproxy.spec
+++ b/spec/haproxy.spec
@@ -53,7 +53,7 @@ possibility not to expose fragile web servers to the net.
 use_regparm="USE_REGPARM=1"
 %endif
 
-make %{?_smp_mflags} CPU="generic" TARGET="linux26" USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1 ${use_regparm}
+make %{?_smp_mflags} CPU="generic" TARGET="linux26" USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1  SMALL_OPTS=-DSYSTEM_MAXCONN=12000  ${use_regparm}
 
 pushd contrib/halog
 make halog


### PR DESCRIPTION
By default, when compiling haproxy, SYSTEM_MAXCONN is set to 2000, therefore if you set in haproxy.cfg a value of maxconn > 2000 for a frontend, backend, the default section or when defining a server, haproxy won't have none of it and won't accept more than  SYSTEM_MAXCONN.

I've raised SYSTEM_MAXCONN so we can accept 8192 (the value set in your config file) simultaneous connections.
